### PR TITLE
ci: point workflow callers at actionsforge reusables

### DIFF
--- a/.github/workflows/commitmsg-conform.yml
+++ b/.github/workflows/commitmsg-conform.yml
@@ -1,0 +1,15 @@
+name: Commit Message Conformance
+
+on:
+  pull_request: {}
+
+permissions:
+  statuses: write
+  checks: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitmsg-conform:
+    uses: actionsforge/actions/.github/workflows/commitmsg-conform.yml@main
+

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,15 @@
+name: Markdown Lint
+
+on:
+  pull_request: {}
+
+permissions:
+  statuses: write
+  checks: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  markdown-lint:
+    uses: actionsforge/actions/.github/workflows/markdown-lint.yml@main
+

--- a/.github/workflows/validate-devschema.yml
+++ b/.github/workflows/validate-devschema.yml
@@ -1,16 +1,24 @@
 name: validate-devschema
+
 on:
   pull_request:
     paths:
-      - '**/devcontainer.json'
+      - "**/devcontainer.json"
   push:
     branches:
       - main
     paths:
-      - '**/devcontainer.json'
+      - "**/devcontainer.json"
 
 jobs:
-  validate-devschema:
-    uses: jdevto/actions/.github/workflows/validate-devschema.yml@main
-    with:
-      verbose: true
+  validate-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+
+      - name: Validate Devcontainer Schema
+        uses: actionsforge/actions-validate-devschema@v1
+        with:
+          verbose: true
+


### PR DESCRIPTION
## Summary
- Retarget workflow `uses:` to `actionsforge/actions` (and `actions-validate-devschema` where needed)
- Ensure separate `markdown-lint.yml` and `commitmsg-conform.yml` callers exist

## Test plan
- [ ] PR checks run against actionsforge reusables

Closes #2